### PR TITLE
FIX: Add missing translation of "Add" button

### DIFF
--- a/views/quantityunits.blade.php
+++ b/views/quantityunits.blade.php
@@ -10,7 +10,7 @@
 	<h1 class="page-header">
 		@yield('title')
 		<a class="btn btn-default" href="{{ $U('/quantityunit/new') }}" role="button">
-			<i class="fa fa-plus"></i>&nbsp;Add
+			<i class="fa fa-plus"></i>&nbsp;{{ $L('Add') }}
 		</a>
 	</h1>
 


### PR DESCRIPTION
The "Add" button was not translated in the 'Quantity units' form.